### PR TITLE
Log GIF retrieval errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 TARGET_OS=linux
 TARGET_ARCH=amd64
 
-SRC=plugin.go
+SRC=plugin.go gifProvider.go
 EXEC=plugin
 CONF=plugin.yaml
 PACKAGE=plugin.tar.gz
@@ -25,6 +25,6 @@ dist: $(EXEC) $(CONF)
 	chmod a+x $(EXEC) && tar -czvf $(PACKAGE) $(EXEC) $(CONF)
 
 test: $(SRC) $(TEST)
-	go test
+	go test .
 clean:
 	rm -rf $(PACKAGE) $(EXEC)

--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ If your Mattermost server is a `linux amd64`, you can download the [release pack
 
 ## Setup
 1. Use the `System Console > Plugins Management > Management` page to upload the `.tar.gz`
-2. Once the plugin is successfully installed, go to the new `System Console > Plugins > Giphy` page, which contains settings for
+2. Once the plugin is successfully installed, go to the new `System Console > Plugins > Giphy` configuration page, and  configure the Giphy API key. The default key is the [public beta key, which is 'subject to rate limit constraints'](https://developers.giphy.com/docs/).
+4. You can also configure the following settings :
     - rating
     - language
     - display size
-3. Activate the plugin in the `System Console > Plugins Management > Management` page
+4. Activate the plugin in the `System Console > Plugins Management > Management` page
 
 ## Usage
 The `/gif cute doggo` command will make a post with a GIF from Giphy that matches the 'cute doggo' query. The GIF will be posted using the user's avatar and name.

--- a/gifProvider.go
+++ b/gifProvider.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"github.com/sanzaru/go-giphy"
+)
+
+// API key used to retrieve Giphy GIF
+const giphyAPIKey = "dc6zaTOxFJmzC"
+
+// gifProvider exposes methods to get GIF URLs
+type gifProvider interface {
+	getGifURL(config *GiphyPluginConfiguration, request string) (string, error)
+}
+
+// giphyProvider get GIF URLs from the Giphy API
+type giphyProvider struct{}
+
+// getGifURL return the URL of a small Giphy GIF that more or less correspond to requested keywords
+func (*giphyProvider) getGifURL(config *GiphyPluginConfiguration, request string) (string, error) {
+	giphy := libgiphy.NewGiphy(giphyAPIKey)
+
+	data, err := giphy.GetTranslate(request, config.Rating, config.Language, false)
+	if err != nil {
+		return "", err
+	}
+	switch config.Rendition {
+	case "fixed_height":
+		return data.Data.Images.Fixed_height.Url, nil
+	case "fixed_height_still":
+		return data.Data.Images.Fixed_height_still.Url, nil
+	case "fixed_height_small":
+		return data.Data.Images.Fixed_height_small.Url, nil
+	case "fixed_height_small_still":
+		return data.Data.Images.Fixed_height_small_still.Url, nil
+	case "fixed_width":
+		return data.Data.Images.Fixed_width.Url, nil
+	case "fixed_width_still":
+		return data.Data.Images.Fixed_width_still.Url, nil
+	case "fixed_width_small":
+		return data.Data.Images.Fixed_width_small.Url, nil
+	case "fixed_width_small_still":
+		return data.Data.Images.Fixed_width_small_still.Url, nil
+	case "downsized":
+		return data.Data.Images.Downsized.Url, nil
+	case "downsized_large":
+		return data.Data.Images.Downsized_large.Url, nil
+	case "downsized_still":
+		return data.Data.Images.Downsized_still.Url, nil
+	case "original":
+		return data.Data.Images.Original.Url, nil
+	case "original_still":
+		return data.Data.Images.Original_still.Url, nil
+	}
+	return data.Data.Images.Fixed_height_small.Url, nil
+}

--- a/gifProvider.go
+++ b/gifProvider.go
@@ -1,11 +1,10 @@
 package main
 
 import (
+	"errors"
+
 	"github.com/sanzaru/go-giphy"
 )
-
-// API key used to retrieve Giphy GIF
-const giphyAPIKey = "dc6zaTOxFJmzC"
 
 // gifProvider exposes methods to get GIF URLs
 type gifProvider interface {
@@ -17,7 +16,11 @@ type giphyProvider struct{}
 
 // getGifURL return the URL of a small Giphy GIF that more or less correspond to requested keywords
 func (*giphyProvider) getGifURL(config *GiphyPluginConfiguration, request string) (string, error) {
-	giphy := libgiphy.NewGiphy(giphyAPIKey)
+	if config.APIKey == "" {
+		return "", errors.New("Giphy API key is empty")
+	}
+
+	giphy := libgiphy.NewGiphy(config.APIKey)
 
 	data, err := giphy.GetTranslate(request, config.Rating, config.Language, false)
 	if err != nil {

--- a/gifProvider_test.go
+++ b/gifProvider_test.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGiphyProviderGetGIFURL(t *testing.T) {
+	p := &giphyProvider{}
+	config := &GiphyPluginConfiguration{Language: "fr", Rating: "", Rendition: "fixed_height_small"}
+	url, err := p.getGifURL(config, "cat")
+	assert.Nil(t, err)
+	assert.NotEmpty(t, url)
+}

--- a/gifProvider_test.go
+++ b/gifProvider_test.go
@@ -1,14 +1,34 @@
 package main
 
 import (
+	"io/ioutil"
 	"testing"
 
+	"github.com/mattermost/mattermost-server/model"
 	"github.com/stretchr/testify/assert"
+	yaml "gopkg.in/yaml.v2"
 )
 
 func TestGiphyProviderGetGIFURL(t *testing.T) {
+	yamlFile, err := ioutil.ReadFile("plugin.yaml")
+	if err != nil {
+		t.Errorf("Could not open plugin configuration which is necessary for this test.")
+		return
+	}
+	var conf *model.Manifest
+	err = yaml.Unmarshal(yamlFile, &conf)
+	if err != nil {
+		t.Errorf("Could not load plugin configuration which is necessary for this test.")
+		return
+	}
+
 	p := &giphyProvider{}
-	config := &GiphyPluginConfiguration{Language: "fr", Rating: "", Rendition: "fixed_height_small"}
+	config := &GiphyPluginConfiguration{
+		Language:  "fr",
+		Rating:    "",
+		Rendition: "fixed_height_small",
+		APIKey:    conf.SettingsSchema.Settings[0].Default.(string),
+	}
 	url, err := p.getGifURL(config, "cat")
 	assert.Nil(t, err)
 	assert.NotEmpty(t, url)

--- a/plugin.go
+++ b/plugin.go
@@ -27,6 +27,7 @@ type GiphyPluginConfiguration struct {
 	Rating    string
 	Language  string
 	Rendition string
+	APIKey    string
 }
 
 // OnActivate register the plugin command

--- a/plugin.go
+++ b/plugin.go
@@ -8,15 +8,10 @@ import (
 	"github.com/mattermost/mattermost-server/model"
 	"github.com/mattermost/mattermost-server/plugin"
 	"github.com/mattermost/mattermost-server/plugin/rpcplugin"
-	"github.com/sanzaru/go-giphy"
 )
 
-const (
-	// API key used to retrieve Giphy GIF
-	giphyAPIKey = "dc6zaTOxFJmzC"
-	// Trigger used to define the slash command
-	trigger = "gif"
-)
+// Trigger used to define the slash command
+const trigger = "gif"
 
 // GiphyPlugin is a Mattermost plugin that adds a /gif slash command
 // to display a GIF based on user keywords.
@@ -24,6 +19,8 @@ type GiphyPlugin struct {
 	api           plugin.API
 	configuration atomic.Value
 	TeamId        string
+	gifProvider   gifProvider
+	enabled       bool
 }
 
 type GiphyPluginConfiguration struct {
@@ -35,6 +32,7 @@ type GiphyPluginConfiguration struct {
 // OnActivate register the plugin command
 func (p *GiphyPlugin) OnActivate(api plugin.API) error {
 	p.api = api
+	p.enabled = true
 	err := api.RegisterCommand(&model.Command{
 		Trigger:          trigger,
 		TeamId:           p.TeamId,
@@ -63,68 +61,45 @@ func (p *GiphyPlugin) OnConfigurationChange() error {
 
 // OnDeactivate unregisters the plugin command
 func (p *GiphyPlugin) OnDeactivate() error {
+	p.enabled = false
 	return p.api.UnregisterCommand(p.TeamId, trigger)
 }
 
 // ExecuteCommand returns a post that displays a GIF choosen using Giphy
 func (p *GiphyPlugin) ExecuteCommand(args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
+	if !p.enabled {
+		return nil, appError("Cannot execute command while the plugin is disabled.", nil)
+	}
+	if p.api == nil {
+		return nil, appError("Cannot access the plugin API.", nil)
+	}
 	cmd := "/" + trigger
 	if strings.HasPrefix(args.Command, cmd) {
 		keywords := strings.Replace(args.Command, cmd, "", 1)
 
-		gifURL, err := p.getGifURL(keywords)
+		gifURL, err := p.gifProvider.getGifURL(p.config(), keywords)
 		if err != nil {
-			return nil, model.NewAppError("Giphy Plugin ExecuteCommand", "Could not get GIF", nil, "", http.StatusBadRequest)
+			return nil, appError("Unable to get GIF URL", err)
 		}
 
 		text := " *[" + keywords + "](" + gifURL + ")*\n" + "![GIF for '" + keywords + "'](" + gifURL + ")"
-		return &model.CommandResponse{ResponseType: "in_channel", Text: text, Username: args.UserId}, nil
+		return &model.CommandResponse{ResponseType: "in_channel", Text: text}, nil
 	}
 
-	return nil, model.NewAppError("Giphy Plugin ExecuteCommand", "Expected trigger "+cmd+" but got "+args.Command, nil, "", http.StatusBadRequest)
+	return nil, appError("Command trigger "+args.Command+"is not supported by this plugin.", nil)
 }
 
-// getGifURL return the URL of a small Giphy GIF that more or less correspond to requested keywords
-func (p *GiphyPlugin) getGifURL(request string) (string, error) {
-	giphy := libgiphy.NewGiphy(giphyAPIKey)
-	config := p.config()
-
-	data, err := giphy.GetTranslate(request, config.Rating, config.Language, false)
+func appError(message string, err error) *model.AppError {
+	errorMessage := ""
 	if err != nil {
-		return "", err
+		errorMessage = err.Error()
 	}
-	switch config.Rendition {
-	case "fixed_height":
-		return data.Data.Images.Fixed_height.Url, nil
-	case "fixed_height_still":
-		return data.Data.Images.Fixed_height_still.Url, nil
-	case "fixed_height_small":
-		return data.Data.Images.Fixed_height_small.Url, nil
-	case "fixed_height_small_still":
-		return data.Data.Images.Fixed_height_small_still.Url, nil
-	case "fixed_width":
-		return data.Data.Images.Fixed_width.Url, nil
-	case "fixed_width_still":
-		return data.Data.Images.Fixed_width_still.Url, nil
-	case "fixed_width_small":
-		return data.Data.Images.Fixed_width_small.Url, nil
-	case "fixed_width_small_still":
-		return data.Data.Images.Fixed_width_small_still.Url, nil
-	case "downsized":
-		return data.Data.Images.Downsized.Url, nil
-	case "downsized_large":
-		return data.Data.Images.Downsized_large.Url, nil
-	case "downsized_still":
-		return data.Data.Images.Downsized_still.Url, nil
-	case "original":
-		return data.Data.Images.Original.Url, nil
-	case "original_still":
-		return data.Data.Images.Original_still.Url, nil
-	}
-	return data.Data.Images.Fixed_height_small.Url, nil
+	return model.NewAppError("Giphy Plugin", message, nil, errorMessage, http.StatusBadRequest)
 }
 
 // Install the RCP plugin
 func main() {
-	rpcplugin.Main(&GiphyPlugin{})
+	plugin := GiphyPlugin{}
+	plugin.gifProvider = &giphyProvider{}
+	rpcplugin.Main(&plugin)
 }

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -6,6 +6,11 @@ backend:
     executable: plugin
 settings_schema:
     settings:
+        - key: APIKey
+          type: text
+          display_name: Giphy API Key
+          help_text: Configure your Giphy API Key (the default key is the beta public key, which is subject to rate limit constraints).
+          default: dc6zaTOxFJmzC
         - key: Rating
           type: text
           display_name: GIF Rating
@@ -115,6 +120,10 @@ settings_schema:
             - display_name: Українська
               value: uk
     footer: |
-        For more information on the rendering styles, see the [Giphy API guide](https://developers.giphy.com/docs/#rendition-guide).
+        Powered by Giphy.
+        
+        * To get your own Giphy API key, follow the instructions in the [developers documentation](https://developers.giphy.com/docs).
 
-        To report an issue, make a suggestion or a contribution, or fork your own version of the plugin, [check the repository](https://github.com/moussetc/mattermost-plugin-giphy).
+        * For more information on the rendering styles, see the [Giphy API guide](https://developers.giphy.com/docs/#rendition-guide).
+
+        * To report an issue, make a suggestion or a contribution, or fork your own version of the plugin, [check the repository](https://github.com/moussetc/mattermost-plugin-giphy).


### PR DESCRIPTION
#2 
Log correctly GIF URL request errors, so the issue can be investigated.