### PR TITLE
change command from 'gif' to 'giphy', have a nice text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # mattermost-plugin-giphy
-This Mattermost plugin adds Giphy Integration by creating a `/gif` slash command (no webhooks required).
+This Mattermost plugin adds Giphy Integration by creating a `/giphy` slash command (no webhooks required).
 
 ## Requirements
 - Mattermost 4.6 (to allow plugins to create slash commands) 
@@ -20,7 +20,7 @@ If your Mattermost server is a `linux amd64`, you can download the [release pack
 3. Activate the plugin in the `System Console > Plugins Management > Management` page
 
 ## Usage
-The `/gif cute doggo` command will make a post with a GIF from Giphy that matches the 'cute doggo' query. The GIF will be posted using the user's avatar and name.
+The `/giphy cute doggo` command will make a post with a GIF from Giphy that matches the 'cute doggo' query. The GIF will be posted using the user's avatar and name.
 
 ## What's next?
 - Adding a preview mode to mimick the Slack Giphy integration

--- a/plugin.go
+++ b/plugin.go
@@ -70,7 +70,7 @@ func (p *GiphyPlugin) OnDeactivate() error {
 func (p *GiphyPlugin) ExecuteCommand(args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
 	cmd := "/" + trigger
 	if strings.HasPrefix(args.Command, cmd) {
-		keywords := strings.TrimLeft(args.Command, cmd+" ")
+		keywords := strings.TrimPrefix(args.Command, cmd+" ")
 
 		gifURL, err := p.getGifURL(keywords)
 		if err != nil {

--- a/plugin.go
+++ b/plugin.go
@@ -15,7 +15,7 @@ const (
 	// API key used to retrieve Giphy GIF
 	giphyAPIKey = "dc6zaTOxFJmzC"
 	// Trigger used to define the slash command
-	trigger = "gif"
+	trigger = "giphy"
 )
 
 // GiphyPlugin is a Mattermost plugin that adds a /gif slash command
@@ -70,14 +70,14 @@ func (p *GiphyPlugin) OnDeactivate() error {
 func (p *GiphyPlugin) ExecuteCommand(args *model.CommandArgs) (*model.CommandResponse, *model.AppError) {
 	cmd := "/" + trigger
 	if strings.HasPrefix(args.Command, cmd) {
-		keywords := strings.Replace(args.Command, cmd, "", 1)
+		keywords := strings.TrimLeft(args.Command, cmd+" ")
 
 		gifURL, err := p.getGifURL(keywords)
 		if err != nil {
 			return nil, model.NewAppError("Giphy Plugin ExecuteCommand", "Could not get GIF", nil, "", http.StatusBadRequest)
 		}
 
-		text := " *[" + keywords + "](" + gifURL + ")*\n" + "![GIF for '" + keywords + "'](" + gifURL + ")"
+		text := "I searched for [" + keywords + "](" + gifURL + ") and found this:\n" + "![GIF for '" + keywords + "'](" + gifURL + ")"
 		return &model.CommandResponse{ResponseType: "in_channel", Text: text, Username: args.UserId}, nil
 	}
 

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -43,7 +43,7 @@ func TestPlugin(t *testing.T) {
 	assert.Nil(t, p.OnActivate(api))
 
 	command := &model.CommandArgs{
-		Command: "/gif cute doggo",
+		Command: "/giphy cute doggo",
 	}
 	response, err := p.ExecuteCommand(command)
 	assert.Nil(t, err)


### PR DESCRIPTION
Hi there,

thank you for your plugin.
We are using it in our Mattermost system. But because our employees are familiar with slack, they are used to using /giphy instead of /gif. Additionally I added a little more text above the found GIF.

I forked it already, but probably you like my changes and accept this PR.
Thank you again.

Best,
Tino