### PR TITLE
FIX - gofmt error (comments)

### DIFF
--- a/server/internal/error/plugin_error.go
+++ b/server/internal/error/plugin_error.go
@@ -21,7 +21,7 @@ type pluginError struct {
 	where string
 }
 
-//appError generates a normalized error for this plugin
+// appError generates a normalized error for this plugin
 func (e *pluginError) FromError(message string, err error) *model.AppError {
 	errorMessage := ""
 	if err != nil {
@@ -30,7 +30,7 @@ func (e *pluginError) FromError(message string, err error) *model.AppError {
 	return model.NewAppError(e.where, message, nil, errorMessage, http.StatusBadRequest)
 }
 
-//appError generates a normalized error for this plugin
+// appError generates a normalized error for this plugin
 func (e *pluginError) FromMessage(message string) *model.AppError {
 	return e.FromError(message, nil)
 }


### PR DESCRIPTION
This PR fixes issues with `gofmt` and the missing space in a couple comments.

## Changes

Simply added a space between the starting `//` and next character in 2 comment in `server/internal/error/plugin_error.go`

-

## Checklist

- [-] if plugin.json was modified, run `make apply` and the generated server/manifest.go is commited
- [-] updated/completed the unit tests
- [✔️] tested on a Mattermost server: _indicate tested version(s) here_ (you can use the [mattermost-preview Docker image](https://docs.mattermost.com/install/docker-local-machine.html) for a quick and painless install)
- [-] updated the docs
- [ ] cleaned the branch git history
- [ ] **rebased** branch on *master* (must be up-to-date at the time of merge)

Fixes #