### PR TITLE
Improved logging

### DIFF
--- a/server/commands.go
+++ b/server/commands.go
@@ -24,11 +24,11 @@ const (
 func (p *Plugin) RegisterCommands() error {
 	unregisterErr := p.API.UnregisterCommand("", triggerGif)
 	if unregisterErr != nil {
-		p.API.LogWarn("Unable to unregister the " + triggerGif + " command" + unregisterErr.Error())
+		p.API.LogWarn("Unable to unregister the command", "trigger", triggerGif, "error", unregisterErr.Error())
 	}
 	unregisterErr = p.API.UnregisterCommand("", triggerGifs)
 	if unregisterErr != nil {
-		p.API.LogWarn("Unable to unregister the " + triggerGifs + " command" + unregisterErr.Error())
+		p.API.LogWarn("Unable to unregister the command", "trigger", triggerGifs, "error", unregisterErr.Error())
 	}
 
 	config := p.getConfiguration()
@@ -79,7 +79,7 @@ func (p *Plugin) executeCommandGif(keywords, caption string, args *model.Command
 	cursor := ""
 	gifURL, errGif := p.gifProvider.GetGifURL(keywords, &cursor, p.configuration.RandomSearch)
 	if errGif != nil {
-		p.API.LogWarn("Error while trying to get GIF URL: " + errGif.Error())
+		p.API.LogWarn("Error while trying to get GIF URL", "error", errGif.Error())
 		return nil, errGif
 	}
 	if gifURL == "" {
@@ -95,7 +95,7 @@ func (p *Plugin) executeCommandGifWithPreview(keywords, caption string, args *mo
 	cursor := ""
 	gifURL, errGif := p.gifProvider.GetGifURL(keywords, &cursor, p.configuration.RandomSearch)
 	if errGif != nil {
-		p.API.LogWarn("Error while trying to get GIF URL: " + errGif.Error())
+		p.API.LogWarn("Error while trying to get GIF URL", "error", errGif.Error())
 		return nil, errGif
 	}
 	if gifURL == "" {

--- a/server/httpHandler.go
+++ b/server/httpHandler.go
@@ -56,7 +56,7 @@ func (p *Plugin) handleHTTPRequest(w http.ResponseWriter, r *http.Request) {
 
 	request, err := parseRequest(r)
 	if err != nil {
-		p.API.LogWarn("Could not parse PostActionIntegrationRequest: "+err.Error(), nil)
+		p.API.LogWarn("Could not parse PostActionIntegrationRequest", "error", err.Error())
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
@@ -204,6 +204,6 @@ func defaultNotifyUserOfError(api plugin.API, botID string, message string, err 
 
 	// Only log technical errors
 	if err != nil {
-		api.LogWarn(message, err)
+		api.LogWarn(message, "error", err)
 	}
 }


### PR DESCRIPTION
## Changes
- Support darwin/arm64 targets for Apple M1 development
- Remove `server/manifest.go`, which still referenced `github.com/mattermost/mattermost-server/v5/model` and seems to be auto-generated now anyway.
- Support explicit `error` fields when logging, e.g.:
```
{"timestamp":"2023-04-14 15:01:32.404 -03:00","level":"warn","msg":"Unable to fetch a new Gif for shuffling","caller":"app/plugin_api.go:979","plugin_id":"com.github.moussetc.mattermost.plugin.giphy","error":"GIF commands: Error calling the Tenor API (HTTP Status: 400 Bad Request), "}
```
- Avoid logging invalid fields and triggering the `invalid key/value pair` error from https://github.com/mattermost/logr/blob/45a1ed2af68b1917e520257b43ac2b809cb8c7f7/sugar.go#L184

## Screenshots

No changes visible to endusers.

## Checklist

- [ ] ~~if plugin.json was modified, run `make apply` and the generated server/manifest.go is commited~~
```
> make apply
make apply is deprecated and has no effect.
```
- [ ] ~~updated/completed the unit tests~~
- [x] tested on a Mattermost server: `master` near April 14, 2023.
- [ ] ~~updated the docs~~
- [x] cleaned the branch git history
- [x] **rebased** branch on *master* (must be up-to-date at the time of merge)