### PR TITLE
DO NOT MERGE ON MAIN debug CI without cached Go packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: '1.16.7'
+        cache: false
 
     - name: Golangci-lint
       uses: golangci/golangci-lint-action@v3


### PR DESCRIPTION
Trying to debug why the testify upgrade breaks the compilation with

"build: server/commands.go#L25
p.API undefined (type *Plugin has no field or method API) (typecheck)"

errors. One idea is that golangci-lint might be unable to retrieve the typings from the Mattermost repository since Mattermost migrated to a monorepo (according to this discussion
https://github.com/golangci/golangci-lint/discussions/2287#discussioncomment-1982414 ).

Currently, the build works on the main branch. Let's disable the cache and see if it still works!

## Summary

<!-- Link to the Issue item this PR solves or resolves. Do open a ticket to discuss code changes before opening a Pull Request. -->
Fixes #XXX

<!-- Write a summary of the PR's goal, and of the changes made to reach it -->

## Screenshots

<!-- In case of changes reclected to the user, please provide screenshots -->

## Checklist

- [ ] updated/completed the unit tests
- [ ] tested on a Mattermost server: _indicate tested version(s) here_ (you can use the [mattermost-preview Docker image](https://docs.mattermost.com/install/docker-local-machine.html) for a quick and painless install)
- [ ] updated the docs
- [ ] cleaned the branch git history
- [ ] **rebased** branch on the target branch (must be up-to-date at the time of merge)

